### PR TITLE
Sl/expose more

### DIFF
--- a/library/Yesod/Session/Memcache.hs
+++ b/library/Yesod/Session/Memcache.hs
@@ -33,6 +33,7 @@ module Yesod.Session.Memcache
     -- * Storage
   , SessionPersistence (..)
   , StorageException (..)
+  , MemcacheExpiration (..)
 
     -- * Key rotation
   , rotateSessionKey
@@ -62,3 +63,4 @@ module Yesod.Session.Memcache
 import Yesod.Session.Memcache.Storage
 import Yesod.Session.Memcache.Yesod
 import Yesod.Session.Storage
+import Yesod.Session.Memcache.Expiration

--- a/library/Yesod/Session/Memcache.hs
+++ b/library/Yesod/Session/Memcache.hs
@@ -62,8 +62,8 @@ module Yesod.Session.Memcache
   , differsOn
   ) where
 
+import Time
+import Yesod.Session.Memcache.Expiration
 import Yesod.Session.Memcache.Storage
 import Yesod.Session.Memcache.Yesod
 import Yesod.Session.Storage
-import Yesod.Session.Memcache.Expiration
-import Time

--- a/library/Yesod/Session/Memcache.hs
+++ b/library/Yesod/Session/Memcache.hs
@@ -11,6 +11,7 @@ module Yesod.Session.Memcache
     -- * Timing
   , TimingOptions (..)
   , defaultTimingOptions
+  , minutes
 
     -- * Timeout
   , Timeout (..)
@@ -23,6 +24,7 @@ module Yesod.Session.Memcache
   , Session (..)
   , SessionKey (..)
   , Time (..)
+  , sessionKeyToCookieValue
 
     -- * Randomization
   , Randomization (..)
@@ -64,3 +66,4 @@ import Yesod.Session.Memcache.Storage
 import Yesod.Session.Memcache.Yesod
 import Yesod.Session.Storage
 import Yesod.Session.Memcache.Expiration
+import Time

--- a/library/Yesod/Session/Storage.hs
+++ b/library/Yesod/Session/Storage.hs
@@ -19,6 +19,7 @@ module Yesod.Session.Storage
   , Session (..)
   , SessionKey (..)
   , Time (..)
+  , sessionKeyToCookieValue
 
     -- * Randomization
   , Randomization (..)


### PR DESCRIPTION
## Description

    Expose `sessionKeyToCookieValue` and `minutes`.
    
    Exposing `minutes` allows a client of this library to write code such
    as:
    
    ```haskell
    expirationInMinutes :: Integer
    expirationInMinutes = 120
    
    ...
    
    defaultTimeout { idle = Just $ minutes (fromInteger expirationInMinutes)}
    
    ...
    ```
    
    Exposing `sessionKeyToCookieValue` allows a client to write code such
    as:
    
    ```haskell
    mkPersistence :: Memcache.Client -> SessionPersistence
    mkPersistence client =
      SessionPersistence
        { databaseKey = sessionKeyToCookieValue
    
    ...
    ```